### PR TITLE
Change IMU used for Gyro Odometry from vectornav to zedX

### DIFF
--- a/sensing/odometry_publisher/launch/gyro_odometry_publisher.launch.py
+++ b/sensing/odometry_publisher/launch/gyro_odometry_publisher.launch.py
@@ -54,7 +54,7 @@ def generate_launch_description():
                         "vehicle_frame_id": FRAME_IDS["base_footprint"],
                     }],
         remappings=[
-            ("sub_imu", TOPIC_NAMES["sensing"]["vectornav"]["imu"]),
+            ("sub_imu", TOPIC_NAMES["sensing"]["zedx"]["imu"]),
             ("sub_can", TOPIC_NAMES["sensing"]["input_can_data"]),
             ("pub_odometry", TOPIC_NAMES["sensing"]["odometry"]["gyro"]),
         ],


### PR DESCRIPTION
Use ZED's stable IMU because vectornav's IMU was not stable.